### PR TITLE
Include 6 byte preamble for all messages

### DIFF
--- a/protocol/src/encoding/v1/mod.rs
+++ b/protocol/src/encoding/v1/mod.rs
@@ -6,7 +6,10 @@ use futures::io::{AsyncRead, AsyncSeek, AsyncWrite};
 use std::io::Result;
 
 use crate::{
-    encoding::{encoding_error, types, MAX_BUFFER_SIZE},
+    encoding::{
+        decode_preamble, encode_preamble, encoding_error, types,
+        MAX_BUFFER_SIZE,
+    },
     Encoding, Error, HandshakeMessage, OpaqueMessage, RequestMessage,
     ResponseMessage, SealedEnvelope, ServerMessage, SessionId,
     SessionRequest, SessionState, TransparentMessage,
@@ -439,6 +442,7 @@ impl Encodable for RequestMessage {
         &self,
         writer: &mut BinaryWriter<W>,
     ) -> Result<()> {
+        encode_preamble(writer).await?;
         let id: u8 = self.into();
         writer.write_u8(id).await?;
         match self {
@@ -461,6 +465,7 @@ impl Decodable for RequestMessage {
         &mut self,
         reader: &mut BinaryReader<R>,
     ) -> Result<()> {
+        decode_preamble(reader).await?;
         let id = reader.read_u8().await?;
         match id {
             types::TRANSPARENT => {
@@ -491,6 +496,7 @@ impl Encodable for ResponseMessage {
         &self,
         writer: &mut BinaryWriter<W>,
     ) -> Result<()> {
+        encode_preamble(writer).await?;
         let id: u8 = self.into();
         writer.write_u8(id).await?;
         match self {
@@ -513,6 +519,7 @@ impl Decodable for ResponseMessage {
         &mut self,
         reader: &mut BinaryReader<R>,
     ) -> Result<()> {
+        decode_preamble(reader).await?;
         let id = reader.read_u8().await?;
         match id {
             types::TRANSPARENT => {

--- a/protocol/src/error.rs
+++ b/protocol/src/error.rs
@@ -7,18 +7,22 @@ pub enum Error {
     #[error("buffer exceeds maximum size {0}")]
     MaxBufferSize(usize),
 
-    /// Error generated when the PEM encoding does not match
-    /// the expected format.
-    #[error("encoding in PEM is invalid")]
-    BadKeypairPem,
+    /// Error generated when encoding identity bytes are invalid.
+    #[error("encoding identity bytes are invalid")]
+    BadEncodingIdentity,
+
+    /// Error generated when encoding versions are mismatched.
+    #[error("encoding version is not supported, expecting version {0} but got version {1}")]
+    EncodingVersion(u16, u16),
 
     /// Error generated decoding the kind for an encoding is invalid.
     #[error("invalid encoding kind identifier {0}")]
     EncodingKind(u8),
 
-    /// Error generated when the envelope encoding flags are invalid.
-    #[error("invalid encoding flags")]
-    InvalidEncodingFlags,
+    /// Error generated when the PEM encoding does not match
+    /// the expected format.
+    #[error("encoding in PEM is invalid")]
+    BadKeypairPem,
 
     /// Error generated when a node expects to be in the transport
     /// protocol state.


### PR DESCRIPTION
Includes 4 bytes for the magic identity and a u16 of the encoding version.

Error if identity bytes are invalid or a version mismatch is detected.

Closes #9.